### PR TITLE
install.sh: Create assets directory.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,7 @@ set -e
 echo "Copying resources folder into $HOME/.config/caveripper/"
 mkdir -p ~/.config/caveripper
 cp -r resources ~/.config/caveripper
+mkdir ~/.config/caveripper/assets
 
 echo "Installing Caveripper"
 cargo install --path ./cli


### PR DESCRIPTION
This fills in a missing step between running `install.sh` and extracting an ISO. CaveRipper (or at least the CLI) requires an assets directory to avoid an unhandled exception, so we need to create that directory before we can begin using the CLI.

This is a stopgap measure and does not touch the .bat, as I do not currently have an easy way to test such a patch from a clean Windows install.

This was successfully tested on my Kubuntu desktop that did not previously have Rust installed or set up. The full set of commands I used (cutting out mistakes such as cloning the wrong branch):
```sh
curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
# Hit [Enter] to default-install Rust.
# Restart terminal. (I use Konsole.)
rustup default nightly
rustup update
# (Organizing that works for my system)
mkdir ~/misc_building
cd misc_building
git clone https://github.com/APerson13/caveripper.git
cd caveripper
./install.sh
```
