### PR TITLE
Pathfinder fixes

### DIFF
--- a/caveripper/src/layout/waypoint.rs
+++ b/caveripper/src/layout/waypoint.rs
@@ -399,15 +399,17 @@ pub fn get_path_to_goal (
         let next_vec = t2;
         let mut _use: Point<3, f32> = Point::<3, f32>([0.0, 0.0, 0.0]);
 
+        // Goal mode is the same as in p2: when true, we are done with waypoints and heading straight to the ship (we're close!)
         if goal_mode == true {
             let diff = goal_pos.sub(cur_pos);
-            // I'm pressuming this means if the distance between points is really small, stop iterating cause we're basically done with the path?
+            // Once we reach this point, stop iterating; we're at the ship!!
             if diff.length() < 20.0 {
                 break;
             }
             _use = diff.normalized();
         } else if next_vec.two_d().dist(&cur_pos.two_d()) < 6.0 {
             // Check if we're almost at the end of the path (second to last node?)
+            // Cast len as signed i32 cause rust crashes if length is -1 (no length at all) cause rust moment :)
             if cur_path_node < ((path.len() as i32 ) - 2) as i32 {
                 cur_path_node += 1;
 
@@ -515,6 +517,7 @@ pub fn get_path_to_goal (
                         _use = d;
                     }
                 } else {
+                    // Cast len as signed i32 cause rust crashes if length is -1 (no length at all) cause rust moment :)
                     if cur_path_node < (path.len() as i32 - 2) as i32 {
                         cur_path_node += 1;
                         // CRMakeRefs

--- a/caveripper/src/layout/waypoint.rs
+++ b/caveripper/src/layout/waypoint.rs
@@ -392,9 +392,10 @@ pub fn get_path_to_goal (
             if diff.length() < 20.0 {
                 break;
             }
+            _use = diff.normalized();
         } else if next_vec.two_d().dist(&cur_pos.two_d()) < 6.0 {
             // Check if we're almost at the end of the path (second to last node?)
-            if cur_path_node < (path.len() - 2) as i32 {
+            if cur_path_node < ((path.len() as i32 ) - 2) as i32 {
                 cur_path_node += 1;
 
                 // CRMakeRefs
@@ -501,7 +502,7 @@ pub fn get_path_to_goal (
                         _use = d;
                     }
                 } else {
-                    if cur_path_node < (path.len() - 2) as i32 {
+                    if cur_path_node < (path.len() as i32 - 2) as i32 {
                         cur_path_node += 1;
                         // CRMakeRefs
                         t0 = if cur_path_node -1 <= -1 {

--- a/caveripper/src/layout/waypoint.rs
+++ b/caveripper/src/layout/waypoint.rs
@@ -197,50 +197,6 @@ impl WaypointGraph {
             }
         }
 
-        
-
-        /*
-        let start_wp = self
-            .iter()
-            .flat_map(|wp| {
-                // Get segments between each combination of two adjacent waypoints
-                self.graph.neighbors(wp.idx).map(move |wp2| (wp, &self.graph[wp2], wp.r, &self.graph[wp2].r))
-            })
-            .map(|(wp1, wp2, r1, r2)| {
-                // Find the point's distance to each line segment
-                let len = wp1.pos.p2_dist(&wp2.pos);
-                if len <= 0.0 {
-                    return (wp1, f32::MAX);
-                }
-
-                let norm = (wp1.pos - wp2.pos).normalized();
-                let t = norm.dot(pos - wp1.pos) / len;
-
-                if t <= 0.0 {
-                    (wp1, pos.p2_dist(&wp1.pos) - wp1.r)
-                } else if t >= 1.0 {
-                    (wp2, pos.p2_dist(&wp2.pos) - wp2.r)
-                } else {
-                    let wp = if pos.p2_dist(&wp1.pos) - wp1.r < pos.p2_dist(&wp2.pos) - wp2.r {
-                        wp1
-                    } else {
-                        wp2
-                    };
-                    (
-                        wp,
-                        ((norm * len * t) + wp1.pos - pos).p2_length()
-                            - ((1.0 - t) * wp1.r)
-                            - (t * wp2.r),
-                    )
-                }
-            })
-            .min_by_key(|(_wp, dist)| FloatOrd(*dist))
-            .unwrap()
-            .0;
-        */
-
-        // let mut ret_j: Vec<&WaypointGraphNode> = vec![start_wp];
-
         // This part is the same - just make a list of all the nodes starting from our closest, heading to the ship
         let mut ret: Vec<&WaypointGraphNode> = vec![best_wp];
         while let Some(backlink) = self.backlink(ret.last().unwrap()) {
@@ -249,7 +205,6 @@ impl WaypointGraph {
                 ret.remove(ret.len() - 2);
             }
         }
-        // iter::once(pos).chain(ret.into_iter().map(|wp| wp.pos))
         ret.into_iter()
     }
 

--- a/caveripper/src/render/render_layout.rs
+++ b/caveripper/src/render/render_layout.rs
@@ -293,19 +293,20 @@ pub fn render_layout<M: AssetManager>(
                 Origin::Center,
             );
 
-            // Debug: draw the waypoint path as well
-            let waypoint_alone = layout.waypoint_graph().carry_path_wps_pos(*tr);
-            for iter in waypoint_alone {
-                treasure_path_layer.place(
-                        Circle {
-                        radius: 10.0,
-                        color: [219, 31, 7, 255].into(),
-                        ..Default::default()
-                    },
-                    (iter * COORD_FACTOR).two_d(),
-                    Origin::Center,
-                );
-            }
+            // @mayabyte I'm keeping this code cause I hate having to rewrite it everytime I need to debug - Moises
+            // // Debug: draw the waypoint path as well
+            // let waypoint_alone = layout.waypoint_graph().carry_path_wps_pos(*tr);
+            // for iter in waypoint_alone {
+            //     treasure_path_layer.place(
+            //             Circle {
+            //             radius: 10.0,
+            //             color: [219, 31, 7, 255].into(),
+            //             ..Default::default()
+            //         },
+            //         (iter * COORD_FACTOR).two_d(),
+            //         Origin::Center,
+            //     );
+            // }
         }
         // Draw our path!
         renderer.add_layer(treasure_path_layer);

--- a/caveripper/src/render/render_layout.rs
+++ b/caveripper/src/render/render_layout.rs
@@ -292,6 +292,20 @@ pub fn render_layout<M: AssetManager>(
                 (*tr * COORD_FACTOR).two_d(),
                 Origin::Center,
             );
+
+            // Debug: draw the waypoint path as well
+            let waypoint_alone = layout.waypoint_graph().carry_path_wps_pos(*tr);
+            for iter in waypoint_alone {
+                treasure_path_layer.place(
+                        Circle {
+                        radius: 10.0,
+                        color: [219, 31, 7, 255].into(),
+                        ..Default::default()
+                    },
+                    (iter * COORD_FACTOR).two_d(),
+                    Origin::Center,
+                );
+            }
         }
         // Draw our path!
         renderer.add_layer(treasure_path_layer);


### PR DESCRIPTION
Fixes the bugs from the previous PR - notably, lines no longer draw infinitely for close treasures, and paths themselves are now 1-to-1 to JHawk's cavegen application (and hopefully Pikmin 2 itself).

Passes all but 1 test case: "test query::test::test_carry_path_dist ... FAILED" I can't debug this on my end, so I may need your help maya looking into this. My gut is because we are calculating paths accurately now, what we thought is a far away treasure is now close (or vice versa), so our expected seeds are incorrect.

I made sure to have 0 warnings this time so plz be nice