### PR TITLE
Searching sequential seeds between 0 and 2^31

### DIFF
--- a/caveripper/src/query/search.rs
+++ b/caveripper/src/query/search.rs
@@ -29,8 +29,15 @@ pub fn find_matching_layouts_parallel<T: Fn() + Send + Sync, F: Fn(u32) + Send +
     let num_found = AtomicUsize::new(0);
 
     scope(|s| {
-        s.spawn_broadcast(|_scope, _broadcast_context| {
+        s.spawn_broadcast(|_scope, broadcast_context| {
+            // divide by 2 before dividing by num threads because the most significant bit is not used in cave generation
+            let seed_space_size = u32::MAX / 2 / (rayon::current_num_threads() as u32);
+            let min_seed: u32 = seed_space_size * (broadcast_context.index() as u32);
+            let max_seed: u32 = min_seed + seed_space_size - 1;
             let mut rng = thread_rng();
+            // end at a random seed between min and max to avoid searching the same seeds every time when not doing an exhaustive search
+            let final_seed: u32 = min_seed + rng.gen_range(0..seed_space_size);
+            let mut curr_seed = final_seed;
             loop {
                 if let Some(deadline_inner) = deadline
                     && Instant::now() > deadline_inner
@@ -49,13 +56,20 @@ pub fn find_matching_layouts_parallel<T: Fn() + Send + Sync, F: Fn(u32) + Send +
                     f();
                 }
 
-                let seed = rng.r#gen();
+                curr_seed = curr_seed + 1;
+                if curr_seed > max_seed {
+                    curr_seed = min_seed;
+                }
 
-                if query.matches(seed, mgr) {
-                    on_found(seed);
+                if query.matches(curr_seed, mgr) {
+                    on_found(curr_seed);
                     if num_to_find.is_some() {
                         num_found.fetch_add(1, Ordering::Relaxed);
                     }
+                }
+                
+                if curr_seed == final_seed { // return if we've searched the whole space
+                    return;
                 }
             }
         });


### PR DESCRIPTION
Tested by exhaustively searching for hallways >20 on ec1 with
```
caveripper search "ec1 hallway > 20" -t 0
```
It searched 2^31 seeds in ~20 minutes.

Also did normal searches without -t 0 to ensure regular functionality and did see seeds returned in expected 10s.